### PR TITLE
Get the latest image for a specific OS from your project.

### DIFF
--- a/index.js
+++ b/index.js
@@ -222,11 +222,11 @@ GCEImages.prototype._parseOsInput = function (os) {
     osParts.name = os;
   } else {
 
-    // Cut out project name if provided.
-    hasProject = os.indexOf("@") !== -1;
+    hasProject = /\//.test(os);
     if(hasProject){
-      project = os.substr(0, os.indexOf("@"));
-      os = os.substr(os.indexOf("@") + 1);
+      var projectAndOs = os.split('/');
+      project = projectAndOs[0];
+      os = projectAndOs[1];
     }
     os.split('-').forEach(function (part) {
       var hasName = osParts.name.length > 0;
@@ -253,11 +253,12 @@ GCEImages.prototype._parseOsInput = function (os) {
     });
   }
 
-  if(hasProject) {
+  if (hasProject) {
     osParts.url = 'https://www.googleapis.com/compute/v1/projects/' + project + '/global/images';
   } else {
     osParts.url = GCEImages.OS_TO_URL[osParts.name];
   }
+
   if (!osParts.url) {
     throw new Error([
       'Cannot find ' + os,

--- a/index.js
+++ b/index.js
@@ -215,9 +215,19 @@ GCEImages.prototype._parseOsInput = function (os) {
     url: ''
   };
 
+  var project = false;
+  var hasProject = false;
+
   if (GCEImages.OS_TO_URL[os]) {
     osParts.name = os;
   } else {
+
+    // Cut out project name if provided.
+    hasProject = os.lastIndexOf("@") !== 0;
+    if(hasProject){
+      project = os.substr(0, os.lastIndexOf("@"));
+      os = os.substr(os.lastIndexOf("@") + 1);
+    }
     os.split('-').forEach(function (part) {
       var hasName = osParts.name.length > 0;
       var hasVersion = osParts.version.length > 0;
@@ -243,8 +253,11 @@ GCEImages.prototype._parseOsInput = function (os) {
     });
   }
 
-  osParts.url = GCEImages.OS_TO_URL[osParts.name];
-
+  if(hasProject) {
+    osParts.url = 'https://www.googleapis.com/compute/v1/projects/' + project + '/global/images';
+  } else {
+    osParts.url = GCEImages.OS_TO_URL[osParts.name];
+  }
   if (!osParts.url) {
     throw new Error([
       'Cannot find ' + os,

--- a/index.js
+++ b/index.js
@@ -223,7 +223,7 @@ GCEImages.prototype._parseOsInput = function (os) {
   } else {
 
     hasProject = /\//.test(os);
-    if(hasProject){
+    if (hasProject) {
       var projectAndOs = os.split('/');
       project = projectAndOs[0];
       os = projectAndOs[1];

--- a/index.js
+++ b/index.js
@@ -223,10 +223,10 @@ GCEImages.prototype._parseOsInput = function (os) {
   } else {
 
     // Cut out project name if provided.
-    hasProject = os.lastIndexOf("@") !== 0;
+    hasProject = os.indexOf("@") !== -1;
     if(hasProject){
-      project = os.substr(0, os.lastIndexOf("@"));
-      os = os.substr(os.lastIndexOf("@") + 1);
+      project = os.substr(0, os.indexOf("@"));
+      os = os.substr(os.indexOf("@") + 1);
     }
     os.split('-').forEach(function (part) {
       var hasName = osParts.name.length > 0;

--- a/readme.md
+++ b/readme.md
@@ -78,6 +78,31 @@ images.getLatest('ubuntu', function (err, image) {
 });
 ```
 
+#### Get the latest image for a specific OS from your project
+
+```js
+images.getLatest('your-project-id-or-name@ubuntu', function (err, image) {
+/*
+  image = {
+    kind: 'compute#image',
+    selfLink: 'https://www.googleapis.com/compute/v1/projects/your-project-id-or-name/global/images/ubuntu-1504-vivid-v20150616a',
+    id: '6610082300127119636',
+    creationTimestamp: '2015-06-17T02:03:55.825-07:00',
+    name: 'ubuntu-1504-vivid-v20150616a',
+    description: 'Canonical, Ubuntu, 15.04, amd64 vivid image built on 2015-06-16',
+    sourceType: 'RAW',
+    rawDisk: { source: '', containerType: 'TAR' },
+    status: 'READY',
+    archiveSizeBytes: '806558757',
+    diskSizeGb: '10',
+    licenses: [
+      'https://www.googleapis.com/compute/v1/projects/ubuntu-os-cloud/global/licenses/ubuntu-1504-vivid'
+    ]
+  }
+*/
+});
+```
+
 #### Get the latest image for a specific version of an OS
 
 ```js

--- a/readme.md
+++ b/readme.md
@@ -81,7 +81,7 @@ images.getLatest('ubuntu', function (err, image) {
 #### Get the latest image for a specific OS from your project
 
 ```js
-images.getLatest('your-project-id-or-name@ubuntu', function (err, image) {
+images.getLatest('your-project-id-or-name/ubuntu', function (err, image) {
 /*
   image = {
     kind: 'compute#image',


### PR DESCRIPTION
Fixes #5

This patch eventually will affect gcloud.compute.

It should add to gcloud.compute ability use disk image from your project :

```javascript
zone.createVM(name, { os: 'my-project-name@ubuntu' }, function(err, vm, operation) {
  // `operation` lets you check the status of long-running tasks.

  operation
    .on('error', function(err) {})
    .on('running', function(metadata) {})
    .on('complete', function(metadata) {
      // Virtual machine created!
    });
});
```