### PR TITLE
Bug fix for _sortNewestFirst

### DIFF
--- a/index.js
+++ b/index.js
@@ -128,7 +128,7 @@ GCEImages.prototype.getLatest = function (options, callback) {
     }
 
     if (Array.isArray(images)) {
-      images = images.sort(self._sortNewestFirst).pop();
+      images = images.sort(self._sortNewestFirst).shift();
     } else {
       for (var image in images) {
         images[image].sort(self._sortNewestFirst).splice(1);
@@ -274,8 +274,8 @@ GCEImages.prototype._filterDeprecated = function (image) {
 };
 
 GCEImages.prototype._sortNewestFirst = function (imageA, imageB) {
-  return imageA.creationTimestamp > imageB.creationTimestamp ? 1
-       : imageA.creationTimestamp < imageB.creationTimestamp ? -1
+  return imageA.creationTimestamp < imageB.creationTimestamp ? 1
+       : imageA.creationTimestamp > imageB.creationTimestamp ? -1
        : 0;
 };
 

--- a/index.js
+++ b/index.js
@@ -274,8 +274,8 @@ GCEImages.prototype._filterDeprecated = function (image) {
 };
 
 GCEImages.prototype._sortNewestFirst = function (imageA, imageB) {
-  return imageA.creationTimestamp < imageB.creationTimestamp ? 1
-       : imageA.creationTimestamp > imageB.createTimestamp ? -1
+  return imageA.creationTimestamp > imageB.creationTimestamp ? 1
+       : imageA.creationTimestamp < imageB.creationTimestamp ? -1
        : 0;
 };
 

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "index.js"
   ],
   "scripts": {
+    "lint": "jshint *.js",
     "test": "mocha --timeout 5000"
   },
   "keywords": [
@@ -30,6 +31,7 @@
   "author": "Stephen Sawchuk <sawchuk@gmail.com>",
   "license": "MIT",
   "devDependencies": {
+    "jshint": "^2.9.4",
     "mocha": "^2.2.5"
   },
   "dependencies": {

--- a/test.js
+++ b/test.js
@@ -108,8 +108,8 @@ describe('gce-images', function () {
         var imageB = { creationTimestamp: '2016-09-25T07:31:52.339-07:00' };
 
         assert.strictEqual(gceImages._sortNewestFirst(imageA, imageB), -1);
-      })
-    })
+      });
+    });
 
     describe('when imageA.creationTimestamp is older than imageB.creationTimestamp', function () {
       it('should return 1', function () {
@@ -117,8 +117,8 @@ describe('gce-images', function () {
         var imageB = { creationTimestamp: '2016-11-17T14:37:55.828-08:00' };
 
         assert.strictEqual(gceImages._sortNewestFirst(imageA, imageB), 1);
-      })
-    })
+      });
+    });
 
     describe('when imageA.creationTimestamp is equal to imageB.creationTimestamp', function () {
       it('should return 0', function () {
@@ -126,7 +126,7 @@ describe('gce-images', function () {
         var imageB = { creationTimestamp: '2016-08-25T07:14:24.426-07:00' };
 
         assert.strictEqual(gceImages._sortNewestFirst(imageA, imageB), 0);
-      })
-    })
-  })
+      });
+    });
+  });
 });

--- a/test.js
+++ b/test.js
@@ -103,20 +103,20 @@ describe('gce-images', function () {
 
   describe('_sortNewestFirst', function () {
     describe('when imageA.creationTimestamp is newer than imageB.creationTimestamp', function () {
-      it('should return 1', function () {
+      it('should return -1', function () {
         var imageA = { creationTimestamp: '2016-10-22T13:06:19.143-08:00' }
         var imageB = { creationTimestamp: '2016-09-25T07:31:52.339-07:00' }
 
-        assert.strictEqual(gceImages._sortNewestFirst(imageA, imageB), 1)
+        assert.strictEqual(gceImages._sortNewestFirst(imageA, imageB), -1)
       })
     })
 
     describe('when imageA.creationTimestamp is older than imageB.creationTimestamp', function () {
-      it('should return -1', function () {
+      it('should return 1', function () {
         var imageA = { creationTimestamp: '2016-10-22T13:06:19.143-08:00' }
         var imageB = { creationTimestamp: '2016-11-17T14:37:55.828-08:00' }
 
-        assert.strictEqual(gceImages._sortNewestFirst(imageA, imageB), -1)
+        assert.strictEqual(gceImages._sortNewestFirst(imageA, imageB), 1)
       })
     })
 

--- a/test.js
+++ b/test.js
@@ -100,4 +100,33 @@ describe('gce-images', function () {
       });
     });
   });
+
+  describe('_sortNewestFirst', function () {
+    describe('when imageA.creationTimestamp is newer than imageB.creationTimestamp', function () {
+      it('should return 1', function () {
+        var imageA = { creationTimestamp: '2016-10-22T13:06:19.143-08:00' }
+        var imageB = { creationTimestamp: '2016-09-25T07:31:52.339-07:00' }
+
+        assert.strictEqual(gceImages._sortNewestFirst(imageA, imageB), 1)
+      })
+    })
+
+    describe('when imageA.creationTimestamp is older than imageB.creationTimestamp', function () {
+      it('should return -1', function () {
+        var imageA = { creationTimestamp: '2016-10-22T13:06:19.143-08:00' }
+        var imageB = { creationTimestamp: '2016-11-17T14:37:55.828-08:00' }
+
+        assert.strictEqual(gceImages._sortNewestFirst(imageA, imageB), -1)
+      })
+    })
+
+    describe('when imageA.creationTimestamp is equal to imageB.creationTimestamp', function () {
+      it('should return 0', function () {
+        var imageA = { creationTimestamp: '2016-08-25T07:14:24.426-07:00' }
+        var imageB = { creationTimestamp: '2016-08-25T07:14:24.426-07:00' }
+
+        assert.strictEqual(gceImages._sortNewestFirst(imageA, imageB), 0)
+      })
+    })
+  })
 });

--- a/test.js
+++ b/test.js
@@ -104,28 +104,28 @@ describe('gce-images', function () {
   describe('_sortNewestFirst', function () {
     describe('when imageA.creationTimestamp is newer than imageB.creationTimestamp', function () {
       it('should return -1', function () {
-        var imageA = { creationTimestamp: '2016-10-22T13:06:19.143-08:00' }
-        var imageB = { creationTimestamp: '2016-09-25T07:31:52.339-07:00' }
+        var imageA = { creationTimestamp: '2016-10-22T13:06:19.143-08:00' };
+        var imageB = { creationTimestamp: '2016-09-25T07:31:52.339-07:00' };
 
-        assert.strictEqual(gceImages._sortNewestFirst(imageA, imageB), -1)
+        assert.strictEqual(gceImages._sortNewestFirst(imageA, imageB), -1);
       })
     })
 
     describe('when imageA.creationTimestamp is older than imageB.creationTimestamp', function () {
       it('should return 1', function () {
-        var imageA = { creationTimestamp: '2016-10-22T13:06:19.143-08:00' }
-        var imageB = { creationTimestamp: '2016-11-17T14:37:55.828-08:00' }
+        var imageA = { creationTimestamp: '2016-10-22T13:06:19.143-08:00' };
+        var imageB = { creationTimestamp: '2016-11-17T14:37:55.828-08:00' };
 
-        assert.strictEqual(gceImages._sortNewestFirst(imageA, imageB), 1)
+        assert.strictEqual(gceImages._sortNewestFirst(imageA, imageB), 1);
       })
     })
 
     describe('when imageA.creationTimestamp is equal to imageB.creationTimestamp', function () {
       it('should return 0', function () {
-        var imageA = { creationTimestamp: '2016-08-25T07:14:24.426-07:00' }
-        var imageB = { creationTimestamp: '2016-08-25T07:14:24.426-07:00' }
+        var imageA = { creationTimestamp: '2016-08-25T07:14:24.426-07:00' };
+        var imageB = { creationTimestamp: '2016-08-25T07:14:24.426-07:00' };
 
-        assert.strictEqual(gceImages._sortNewestFirst(imageA, imageB), 0)
+        assert.strictEqual(gceImages._sortNewestFirst(imageA, imageB), 0);
       })
     })
   })


### PR DESCRIPTION
The comparator function `_sortNewestFirst` returns incorrect values, so that when used for sorting in `getLatest`, it result in incorrectly returned image.